### PR TITLE
Ensure force kill timeout isn't keeping process alive

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function createMiddleware(server, opts) {
     setTimeout(function () {
       options.logger.error('Could not close connections in time, forcefully shutting down')
       process.exit(1)
-    }, options.forceTimeout)
+    }, options.forceTimeout).unref()
 
     server.close(function () {
       options.logger.info('Closed out remaining connections.')


### PR DESCRIPTION
👋  I don't know if you still use this module? I was checking it out in relation to something similar I'm working on and noticed what I think is a bug.

I thought I'd throw this PR up quickly – I didn't add any tests but I did run the existing ones and they apssed. I'm pretty sure the behaviour of this module would be to wait up to `forceTimeout` ms _every_ time the process is killed in non-dev envs because the timeout would keep the event loop non-empty.

See [`unref()`](https://nodejs.org/api/timers.html#timers_timeout_unref) for more info.